### PR TITLE
Agregar corrector de sintaxis al editor de codigo

### DIFF
--- a/frontend/angular/src/app/shared/editor/editor.component.html
+++ b/frontend/angular/src/app/shared/editor/editor.component.html
@@ -5,7 +5,8 @@
       <ngx-codemirror
         class="cm-panel"
         [(ngModel)]="codigo"
-        [options]="cmOptions">
+        [options]="cmOptions"
+        (editorInitialized)="onEditorInit($event)">
       </ngx-codemirror>
 
       <ngx-codemirror

--- a/frontend/angular/src/app/shared/editor/editor.component.ts
+++ b/frontend/angular/src/app/shared/editor/editor.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { CodemirrorModule } from '@ctrl/ngx-codemirror';
 
-// Importa lint y modo python para CodeMirror
+// Importacion de lint y modo python para CodeMirror
 import * as CodeMirrorNS from 'codemirror';
 import 'codemirror/addon/lint/lint';
 import 'codemirror/addon/lint/lint.css';
@@ -11,7 +11,7 @@ import 'codemirror/mode/python/python';
 (window as any).CodeMirror = CodeMirrorNS;
 declare const CodeMirror: any;
 
-// --- Lint global para CodeMirror y Pyodide ---
+// Lint global para CodeMirror y Pyodide 
 function pythonLint(code: string) {
   const pyodide = (window as any).pyodideInstance;
   if (!pyodide) {
@@ -24,19 +24,29 @@ function pythonLint(code: string) {
   } catch (error: any) {
     let message = error.message || error.toString();
     let line = 0;
-    const lineMatch = message.match(/line (\d+)/);
-    if (lineMatch) {
-      line = parseInt(lineMatch[1], 10) - 1;
+    // Buscar la línea del "<input>"
+    const inputLineMatch = message.match(/File "<input>", line (\d+)/);
+    if (inputLineMatch) {
+      line = parseInt(inputLineMatch[1], 10) - 1;
     }
-    console.log('[Editor] Error de sintaxis detectado:', message, 'en línea', line + 1);
+    // Mostrar mensaje
+    let userMessage = 'Error de sintaxis';
+    if (message.includes('SyntaxError')) {
+      userMessage = message.replace('SyntaxError:', '').trim();
+    } else if (message) {
+      userMessage = message;
+    }
+    console.log('[Editor] Error de sintaxis detectado:', userMessage, 'en línea', line + 1);
+    // Marca toda la línea
     return [{
       from: CodeMirror.Pos(line, 0),
       to: CodeMirror.Pos(line, 100),
-      message,
+      message: userMessage,
       severity: 'error'
     }];
   }
 }
+
 
 @Component({
   selector: 'app-editor',
@@ -74,7 +84,7 @@ export class EditorComponent implements OnInit {
     mode: 'text/plain',
     lineNumbers: false,
     placeholder: 'Escribe tus inputs…',
-    lint: false // ¡IMPORTANTE! No hacer lint en el input
+    lint: false 
   };
 
   pyodide: any;
@@ -89,12 +99,12 @@ export class EditorComponent implements OnInit {
     console.log('[Editor] Pyodide cargado desde CDN');
   }
 
-  // Vincula instancia de CodeMirror
+  // Vincular instancia de CodeMirror
   onEditorInit(instance: any) {
     this.codeMirrorInstance = instance;
   }
 
-  // Fuerza el lint en cada cambio de código
+  // Forzar el lint en cada cambio de código
   onCodigoChange() {
     if (this.codeMirrorInstance) {
       this.codeMirrorInstance.performLint();

--- a/frontend/angular/src/styles.scss
+++ b/frontend/angular/src/styles.scss
@@ -1,4 +1,29 @@
 
+/* CodeMirror Lint Styles - habilita subrayado de errores */
+.CodeMirror-lint-mark-error {
+  border-bottom: 2px wavy #ff0000;
+  background: none;
+}
+.CodeMirror-lint-mark-warning {
+  border-bottom: 2px dotted orange;
+  background: none;
+}
+.CodeMirror-lint-tooltip {
+  background: #ffd2d2;
+  color: #a33;
+  border: 1px solid #a33;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.9em;
+  z-index: 100;
+}
+.CodeMirror-lint-marker-error {
+  color: #ff0000;
+}
+.CodeMirror-lint-marker-warning {
+  color: orange;
+}
+
 /* Estilos globales y mobile-first */
 body {
     margin: 0;


### PR DESCRIPTION
Se extendio la funcionalidad del editor de codigo:

- Se agrego un linter en el gutter que verifica el error de sintaxis
- Se agrego tambien undercurl(subrayado) para controlar el error de sintaxis
- Para realizar estos cambios se modifico principalmente **editor.component.ts** donde se importaron los **lint** para **CodeMirror** y se utiliza **pyodide**  para la verificacion de sintaxis.

como probar:

- Abrir el editor y escribir codigo python con errores de sintaxis
ejemplo:
print(a
def patata(:
etc...
- Cuando haya errores aparecera un linter en el gutter del editor, es decir en el lateral izquierdo antes de los numeros.
Tambien se marcara un undercurl (subrayado) en color rojo el texto que esta con error, y cando se pase el cursor del mouse ensima del error mostrara mas informacion del error.

@Frosmin